### PR TITLE
dcos-1886 don't crash if invalid json commands

### DIFF
--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -361,6 +361,16 @@ def test_update_bad_type():
         assert stdout == b''
 
 
+def test_update_invalid_request():
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'marathon', 'app', 'update', '{', 'instances'])
+    assert returncode == 1
+    assert stdout == b''
+    stderr = stderr.decode()
+    assert stderr.startswith('Error while fetching')
+    assert stderr.endswith('HTTP 400: Bad Request\n')
+
+
 def test_update_app():
     with _zero_instance_app():
         returncode, stdout, stderr = exec_command(

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -54,6 +54,11 @@ def _to_exception(response):
     if isinstance(response, Exception):
         return DCOSException(_default_marathon_error(str(response)))
 
+    if response.status_code == 400:
+        return DCOSException(
+            'Error while fetching [{0}]: HTTP {1}: {2}'.format(
+                response.request.url, response.status_code, response.reason))
+
     message = response.json().get('message')
     if message is None:
         errs = response.json().get('errors')


### PR DESCRIPTION
Instead of leaving a stack trace, show more helpful message. 
```
Tamars-MacBook-Pro:dcos-cli tamar$ dcos marathon app update {"instances": 2}
Error: No JSON object could be decoded
```

In this command, app-id wasn't specified, and we parsed it as `"{"` with properties `'"instances": 2}'`, which is what caused the stacktrace. 