### PR TITLE
fix return type from [Error] to [str]

### DIFF
--- a/dcos/package.py
+++ b/dcos/package.py
@@ -1009,7 +1009,7 @@ class Registry():
         """Validates a package registry.
 
         :returns: Validation errors
-        :rtype: [Error]
+        :rtype: [str]
         """
 
         # TODO(CD): implement these checks in pure Python?
@@ -1025,8 +1025,7 @@ class Registry():
                                            '1-validate-packages.sh')
             result = subprocess.call(validate_script)
         if result is not 0:
-            return [Error(
-                'Source tree is not valid [{}]'.format(self._base_path))]
+            return ["Source tree is not valid [{}]".format(self._base_path)]
         else:
             return []
 


### PR DESCRIPTION
Since the errors get put into util.list_to_err which expects [str].