### PR TITLE
Update marathon-group-schema.json

### DIFF
--- a/cli/dcoscli/data/marathon-group-schema.json
+++ b/cli/dcoscli/data/marathon-group-schema.json
@@ -62,7 +62,14 @@
                                 "parameters": {
                                     "items": {
                                         "additionalProperties": false,
-                                        "properties": {},
+                                        "properties": { 
+                                            "key": { 
+                                                "type": "string"
+                                            }, 
+                                            "value": { 
+                                                "type": "string"
+                                            } 
+                                        },
                                         "required": [
                                             "key",
                                             "value"


### PR DESCRIPTION
    $ python --version
Python 2.7.9

The validation did not work with "properties": {}. I got either this:
Error: missing required property 'key'.
Error: missing required property 'value'.

Or this:
Error: Additional properties are not allowed ('key' was unexpected)
Error: Additional properties are not allowed ('value' was unexpected)