### PR TITLE
accept no_proxy env variable

### DIFF
--- a/dcos/http.py
+++ b/dcos/http.py
@@ -82,8 +82,7 @@ def request(method,
 
     try:
         with requests.Session() as session:
-            response = session.send(request.prepare(), timeout=timeout,
-                                    proxies=util.get_proxy_dict_from_env())
+            response = session.send(request.prepare(), timeout=timeout)
     except Exception as ex:
         raise to_exception(ex)
 

--- a/dcos/util.py
+++ b/dcos/util.py
@@ -583,21 +583,6 @@ def stream(fn, objs):
             yield job, jobs[job]
 
 
-def get_proxy_dict_from_env():
-    """ Returns dict with proxy parameters
-
-    :returns: Dict with proxy parameters
-    :rtype: dict
-    """
-
-    proxies = dict()
-
-    for name, value in os.environ.items():
-        if value and (name == 'http_proxy' or name == 'https_proxy'):
-            proxies[name] = value
-    return proxies
-
-
 def get_ssh_options(config_file, options):
     """Returns the SSH arguments for the given parameters.  Used by
     commands that wrap SSH.


### PR DESCRIPTION
The requests library already processes the http{s}_proxy and no_proxy
env variables, and using the `proxies` argument was overwriting, and
thus invalidating the no_proxy env variable.