### PR TITLE
Fix SSH to DCOS nodes

### DIFF
--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -111,10 +111,6 @@ def test_node_log_invalid_lines():
                    returncode=1)
 
 
-def test_node_ssh_master():
-    _node_ssh(['--master'])
-
-
 def test_node_ssh_slave():
     slave_id = mesos.DCOSClient().get_state_summary()['slaves'][0]['id']
     _node_ssh(['--slave={}'.format(slave_id)])

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -1,5 +1,6 @@
 import fnmatch
 import itertools
+import json
 import os
 
 from dcos import http, util
@@ -66,6 +67,12 @@ class DCOSClient(object):
         base_url = (self._mesos_master_url or
                     urllib.parse.urljoin(self._dcos_url, 'mesos/'))
         return urllib.parse.urljoin(base_url, path)
+
+    def master_ip(self):
+        path = urllib.parse.urljoin(self._dcos_url, 'metadata')
+        response = urllib.request.urlopen(path).read()
+        data = json.loads(response)
+        return data["PUBLIC_IPV4"]
 
     # TODO (mgummelt): this doesn't work with self._mesos_master_url
     def slave_url(self, slave_id, path):


### PR DESCRIPTION
Fixing Issue #291 and #293.  The old method of retrieving the Mesos master's ip
was returning the internal private IP.  We now retrieve the public IP
for the master node.  Further, ssh to slaves didn't work because we
weren't being redirected through the master as described in the code
comments.  This PR also fixes that problem.  See issue #293.

The old ssh to master test which used to pass has been removed.  This
change broke the test, but the test didn't actually prove that anything
worked.  I've filed issue #294 to fix the ssh tests.

ssh now works to both master and slave nodes in DCOS clusters.