### PR TITLE
Resolve HTTP proxy configuration on the first call

### DIFF
--- a/dcos/http.py
+++ b/dcos/http.py
@@ -77,22 +77,21 @@ def request(method,
         kwargs['headers'] = {'Accept': 'application/json'}
 
     timeout = timeout or _timeout()
-    request = requests.Request(
-        method=method,
-        url=url,
-        **kwargs)
 
     logger.info(
         'Sending HTTP [%r] to [%r]: %r',
-        request.method,
-        request.url,
-        request.headers)
+        method,
+        url,
+        kwargs.get('headers'))
 
     try:
-        with requests.Session() as session:
-            response = session.send(request.prepare(), timeout=timeout)
+        response = requests.request(
+            method=method,
+            url=url,
+            timeout=timeout,
+            **kwargs)
     except Exception as ex:
-        logger.exception('Error making HTTP request: %r', request.url)
+        logger.exception('Error making HTTP request: %r', url)
 
         raise to_exception(ex)
 


### PR DESCRIPTION
Through manual testing we nocited that the cli wasn't resolving proxy
setting during the first HTTP call in a session. This was because we
were using `session.send` method which doesn't do proxy resolution.
The higher-level methods: `session.request`, `session.get`, etc. do
proxy setting resolution.