### PR TITLE
Fix package install test

### DIFF
--- a/cli/tests/integrations/common.py
+++ b/cli/tests/integrations/common.py
@@ -196,6 +196,27 @@ def watch_all_deployments(count=300):
         watch_deployment(dep['id'], count)
 
 
+def wait_for_service(service_name, max_count=300):
+    """Wait for service to register with Mesos
+
+    :param service_name: name of service
+    :type service_name: str
+    :param max_count: max number of seconds to wait
+    :type max_count: int
+    :rtype: None
+    """
+
+    count = 0
+    while count < max_count:
+        services = get_services()
+
+        for service in services:
+            if service['name'] == service_name:
+                return
+
+        count += 1
+
+
 def add_app(app_path, deploy=False):
     """ Add an app, and wait for it to deploy
 

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -10,7 +10,7 @@ import pytest
 
 from .common import (assert_command, assert_lines, delete_zk_nodes,
                      exec_command, file_bytes, file_json, get_services,
-                     service_shutdown, watch_all_deployments)
+                     service_shutdown, wait_for_service, watch_all_deployments)
 
 
 @pytest.fixture(scope="module")
@@ -249,8 +249,12 @@ Please create a JSON file with the appropriate options, and pass the \
 def test_install(zk_znode):
     _install_chronos()
     watch_all_deployments()
+    wait_for_service('chronos')
     _uninstall_chronos()
-    get_services(expected_count=1, args=['--inactive'])
+    watch_all_deployments()
+    services = get_services(args=['--inactive'])
+    assert len([service for service in services
+                if service['name'] == 'chronos']) == 0
 
 
 def test_install_missing_options_file():


### PR DESCRIPTION
Sometimes `dcos service --inactive` returns other services created by other tests. E.g. `marathon-user`, etc.