### PR TITLE
ability to configure ssl verification

### DIFF
--- a/cli/dcoscli/data/config-schema/core.json
+++ b/cli/dcoscli/data/config-schema/core.json
@@ -42,6 +42,12 @@
         "minimum": 1,
         "title": "Request timeout in seconds",
         "description": "Request timeout in seconds"
+    },
+    "ssl_verify": {
+      "type": "boolean",
+      "default": true,
+      "title": "Verify SSL Certificates",
+      "description": "Whether to verify SSL certificates"
     }
   },
   "additionalProperties": false

--- a/dcos/http.py
+++ b/dcos/http.py
@@ -12,9 +12,11 @@ def _timeout():
     config = util.get_config()
     return config.get('core.timeout', DEFAULT_TIMEOUT)
 
+
 def _ssl_verify():
     config = util.get_config()
     return config.get('core.ssl_verify', True)
+
 
 def _default_is_success(status_code):
     """Returns true if the success status is between [200, 300).

--- a/dcos/http.py
+++ b/dcos/http.py
@@ -1,6 +1,7 @@
 import requests
 from dcos import util
 from dcos.errors import DCOSException
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 logger = util.get_logger(__name__)
 
@@ -11,6 +12,9 @@ def _timeout():
     config = util.get_config()
     return config.get('core.timeout', DEFAULT_TIMEOUT)
 
+def _ssl_verify():
+    config = util.get_config()
+    return config.get('core.ssl_verify', True)
 
 def _default_is_success(status_code):
     """Returns true if the success status is between [200, 300).
@@ -77,6 +81,7 @@ def request(method,
         kwargs['headers'] = {'Accept': 'application/json'}
 
     timeout = timeout or _timeout()
+    ssl_verify = _ssl_verify()
 
     logger.info(
         'Sending HTTP [%r] to [%r]: %r',
@@ -84,11 +89,15 @@ def request(method,
         url,
         kwargs.get('headers'))
 
+    if not ssl_verify:
+        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
     try:
         response = requests.request(
             method=method,
             url=url,
             timeout=timeout,
+            verify=ssl_verify,
             **kwargs)
     except Exception as ex:
         logger.exception('Error making HTTP request: %r', url)


### PR DESCRIPTION
having the ability to turn off ssl verification can be useful when mesos and/or marathon UIs are behind SSL using self-signed certificates