### PR TITLE
dcos-2471 allow marathon app updates during a deployment

### DIFF
--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -666,7 +666,11 @@ def _validate_update(current_resource, properties, schema):
 
 def _clean_up_resource_definition(properties):
     """
-    Remove task properties and nulls from resource definition
+    Remove non user-specified properties and nulls from resource definition.
+    We remove fields that marathon adds because they aren't in the json-schema
+    because a user should not specity them. When we do a `get` to see the
+    current resource, we may see these fields, but leaving them will cause us
+    to unnecessarily fail the schema validation.
 
     :param properties: resource JSON
     :type properties: dict
@@ -674,15 +678,23 @@ def _clean_up_resource_definition(properties):
     :rtype: dict
     """
     clean_properties = {}
+    ignore_properties = ["deployments", "lastTaskFailure", "tasks",
+                         "tasksRunning", "tasksHealthy", "tasksUnhealthy",
+                         "tasksStaged"]
     for k, v in properties.items():
-        if v:
-            if k in ["apps", "groups"]:
-                clean_properties[k] = [_clean_up_resource_definition(v[0])]
-            # Remove fields that marathon adds. These aren't in the json-schema
-            # because a user should not specify them. When we do a `get` to see
-            # the current schema, we may see these fields, but leaving them
-            # will cause us to unnecessarily fail the schema validation.
-            elif not k.startswith("task") and k != "lastTaskFailure":
+        if v is not None and k not in ignore_properties:
+            # iterate through dict/list(s) to check all properties
+            if isinstance(v, list):
+                v = [value for value in v if value]
+                clean_properties[k] = [
+                    _clean_up_resource_definition(elem)
+                    if isinstance(elem, dict)
+                    else elem
+                    for elem in v
+                ]
+            elif isinstance(v, dict):
+                clean_properties[k] = _clean_up_resource_definition(v)
+            else:
                 clean_properties[k] = v
 
     return clean_properties

--- a/cli/tests/data/marathon/apps/cleaned_response.json
+++ b/cli/tests/data/marathon/apps/cleaned_response.json
@@ -1,0 +1,62 @@
+{
+    "apps": [
+        {
+            "backoffFactor": 1.15,
+            "backoffSeconds": 1,
+            "maxLaunchDelaySeconds": 3600,
+            "cmd": "python3 -m http.server 8080",
+            "constraints": [],
+            "container": {
+                "docker": {
+                    "image": "python:3",
+                    "network": "BRIDGE",
+                    "portMappings": [
+                        {
+                            "containerPort": 8080,
+                            "hostPort": 0,
+                            "servicePort": 9000,
+                            "protocol": "tcp"
+                        },
+                        {
+                            "containerPort": 161,
+                            "hostPort": 0,
+                            "protocol": "udp"
+                        }
+                    ]
+                },
+                "type": "DOCKER",
+                "volumes": []
+            },
+            "cpus": 0.5,
+            "dependencies": [],
+            "disk": 0.0,
+            "env": {},
+            "executor": "",
+            "healthChecks": [
+                {
+                    "gracePeriodSeconds": 5,
+                    "intervalSeconds": 20,
+                    "maxConsecutiveFailures": 3,
+                    "path": "/",
+                    "portIndex": 0,
+                    "protocol": "HTTP",
+                    "timeoutSeconds": 20
+                }
+            ],
+            "id": "/bridged-webapp",
+            "instances": 2,
+            "mem": 64.0,
+            "ports": [
+                10000,
+                10001
+            ],
+            "requirePorts": false,
+            "storeUrls": [],
+            "upgradeStrategy": {
+                "minimumHealthCapacity": 1.0
+            },
+            "uris": [],
+            "version": "2014-09-25T02:26:59.256Z"
+        }
+    ]
+}

--- a/cli/tests/data/marathon/apps/response.json
+++ b/cli/tests/data/marathon/apps/response.json
@@ -1,0 +1,70 @@
+{
+    "apps": [
+        {
+            "args": null,
+            "backoffFactor": 1.15,
+            "backoffSeconds": 1,
+            "maxLaunchDelaySeconds": 3600,
+            "cmd": "python3 -m http.server 8080",
+            "constraints": [],
+            "container": {
+                "docker": {
+                    "image": "python:3",
+                    "network": "BRIDGE",
+                    "portMappings": [
+                        {
+                            "containerPort": 8080,
+                            "hostPort": 0,
+                            "servicePort": 9000,
+                            "protocol": "tcp"
+                        },
+                        {
+                            "containerPort": 161,
+                            "hostPort": 0,
+                            "protocol": "udp"
+                        }
+                    ]
+                },
+                "type": "DOCKER",
+                "volumes": []
+            },
+            "cpus": 0.5,
+            "dependencies": [],
+            "deployments": [],
+            "disk": 0.0,
+            "env": {},
+            "executor": "",
+            "healthChecks": [
+                {
+                    "command": null,
+                    "gracePeriodSeconds": 5,
+                    "intervalSeconds": 20,
+                    "maxConsecutiveFailures": 3,
+                    "path": "/",
+                    "portIndex": 0,
+                    "protocol": "HTTP",
+                    "timeoutSeconds": 20
+                }
+            ],
+            "id": "/bridged-webapp",
+            "instances": 2,
+            "mem": 64.0,
+            "ports": [
+                10000,
+                10001
+            ],
+            "requirePorts": false,
+            "storeUrls": [],
+            "tasksRunning": 2,
+            "tasksHealthy": 2,
+            "tasksUnhealthy": 0,
+            "tasksStaged": 0,
+            "upgradeStrategy": {
+                "minimumHealthCapacity": 1.0
+            },
+            "uris": [],
+            "user": null,
+            "version": "2014-09-25T02:26:59.256Z"
+        }
+    ]
+}

--- a/cli/tests/unit/test_marathon_validation.py
+++ b/cli/tests/unit/test_marathon_validation.py
@@ -1,0 +1,64 @@
+import collections
+import json
+
+import pkg_resources
+from dcos import util
+from dcoscli.marathon import main
+
+import pytest
+
+ResourceData = collections.namedtuple(
+    'ResourceData',
+    ['properties', 'expected'])
+
+
+def get_clean_app_response():
+    return json.loads(
+        pkg_resources.resource_string(
+            'tests',
+            'data/marathon/apps/cleaned_response.json').decode('utf-8'))
+
+
+@pytest.fixture(params=[
+    ResourceData(
+        properties=json.loads(
+            pkg_resources.resource_string(
+                'tests',
+                'data/marathon/apps/response.json').decode('utf-8')),
+        expected=get_clean_app_response()
+        )])
+def resource_data(request):
+    return request.param
+
+
+def test_clean_up_resource_definition(resource_data):
+    result = main._clean_up_resource_definition(resource_data.properties)
+    assert result == resource_data.expected
+
+
+schema = main._data_schema()
+
+
+ValidationCheck = collections.namedtuple(
+    'ValidationCheck',
+    ['properties', 'expected'])
+
+
+@pytest.fixture(params=[
+    ValidationCheck(
+        properties=get_clean_app_response(),
+        expected=[]),
+    ValidationCheck(
+        properties=json.loads(
+            pkg_resources.resource_string(
+                'tests',
+                'data/marathon/groups/complicated.json').decode('utf-8')),
+        expected=[])
+    ])
+def validation_check(request):
+    return request.param
+
+
+def test_validation(validation_check):
+    result = util.validate_json(validation_check.properties, schema)
+    assert result == validation_check.expected


### PR DESCRIPTION
Since we are using the resource definition from marathon, it contains fields that should not be specified by users which need to be removed before validating the update. 