### PR TITLE
[DCOS-610] Moved "missing options file" message for `dcos package install

### DIFF
--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -339,6 +339,8 @@ def _install(package_name, package_version, options_path, app_id, cli, app,
             msg = "Package [{}] not available".format(package_name)
         raise DCOSException(msg)
 
+    user_options = _user_options(options_path)
+
     pkg_json = pkg.package_json(pkg_revision)
     pre_install_notes = pkg_json.get('preInstallNotes')
     if pre_install_notes:
@@ -346,8 +348,6 @@ def _install(package_name, package_version, options_path, app_id, cli, app,
         if not _confirm('Continue installing?', yes):
             emitter.publish('Exiting installation.')
             return 0
-
-    user_options = _user_options(options_path)
 
     options = pkg.options(pkg_revision, user_options)
 

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -260,8 +260,6 @@ def test_install_missing_options_file():
         ['dcos', 'package', 'install', 'chronos', '--yes',
          '--options=asdf.json'],
         returncode=1,
-        stdout=b'We recommend a minimum of one node with at least 1 CPU and '
-               b'2GB of RAM available for the Chronos Service.\n',
         stderr=b"Error opening file [asdf.json]: No such file or directory\n")
 
 


### PR DESCRIPTION
--options=<missing.json>` to the beginning of stderr