### PR TITLE
Add appId to example and made the two texts consistent ('E.g.' v/s 'Usage')

### DIFF
--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -340,7 +340,7 @@ def _get_resource(resource):
         raise DCOSException(
             "We currently don't support reading from the TTY. Please "
             "specify an application JSON.\n"
-            "Usage: dcos marathon app add < app_resource.json")
+            "E.g.: dcos marathon app add your-app-id < app_resource.json")
 
     return util.load_json(sys.stdin)
 
@@ -745,7 +745,7 @@ def _parse_properties(properties, schema):
             raise DCOSException(
                 "We currently don't support reading from the TTY. Please "
                 "specify an application JSON.\n"
-                "E.g. dcos marathon app update < app_update.json")
+                "E.g. dcos marathon app update your-app-id < app_update.json")
         else:
             return util.load_jsons(sys.stdin.read())
 

--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -689,7 +689,8 @@ def test_app_add_no_tty():
     assert stdout == b''
     assert stderr == (b"We currently don't support reading from the TTY. "
                       b"Please specify an application JSON.\n"
-                      b"Usage: dcos marathon app add < app_resource.json\n")
+                      b"E.g.: dcos marathon app add your-app-id"
+                      b" < app_resource.json\n")
 
 
 def _list_apps(app_id=None):


### PR DESCRIPTION
(This is mostly splitting hairs)
App id was missing from the example text. Also we were using "E.g." in one place "Usage" in other