### PR TITLE
Escape newlines when rendering template

### DIFF
--- a/dcos/util.py
+++ b/dcos/util.py
@@ -487,7 +487,7 @@ def render_mustache_json(template, data):
     """
 
     try:
-        r = CustomJsonRenderer()
+        r = CustomJsonRenderer(escape=lambda s: s.replace("\n", "\\n"))
         rendered = r.render(template, data)
     except Exception as e:
         logger.exception(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,7 +11,7 @@ def test_render_mustache_json():
     template = '{ "x": {{{xs}}}, "y": {{{ys}}}, "z": "{{{z}}}"}'
     xs = [1, 2, 3]
     ys = {'y1': 1, 'y2': 2}
-    z = 'abc'
+    z = 'abc\ndef'
     data = {'xs': xs, 'ys': ys, 'z': z}
     result = util.render_mustache_json(template, data)
 


### PR DESCRIPTION
If we read an options json file which includes properly encoded newlines
like this:

    { "foo": "bar\nbaz" }

And have a template like:

    { "bzz": "{{ foo }}" }

Without this change, the resulting file would be:

    { "bzz": "bar
    baz" }

which isn't valid json.

Alternatively people would need to double escape the newline like this:

    { "foo": "bar\\nbaz" }

which is quite confusing and unexpected from a users perspective.

One thing to keep in mind is that with this change, it's not possible to
use newlines outside strings. Since that should be very uncommon and
unreadable, I don't think we need/should support that.

The proper solution to all this would be to stop using template to
render json. The simplest alternative would be to simply override
elements by merging marathon.json with some user defined json. If that
doesn't work for all use cases, we would need to come up with a json
transformator (think XSLT) or DSL.