### PR TITLE
Stop handling status 409 specially

### DIFF
--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -672,8 +672,9 @@ def test_app_locked_error():
         assert_command(
             ['dcos', 'marathon', 'app', 'stop', 'sleep-two-instances'],
             returncode=1,
-            stderr=(b'App or group is locked by one or more deployments. '
-                    b'Override with --force.\n'))
+            stderr=(b"Error: App is locked by one or more deployments. "
+                    b"Override with the option '?force=true'. View details"
+                    b" at '/v2/deployments/<DEPLOYMENT_ID>'.\n"))
 
 
 def test_app_add_no_tty():

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -71,10 +71,6 @@ def _to_exception(response):
             pass
 
         return DCOSException(msg)
-    elif response.status_code == 409:
-        return DCOSException(
-            'App or group is locked by one or more deployments. '
-            'Override with --force.')
 
     try:
         response_json = response.json()


### PR DESCRIPTION
409 can include a meaningful error message like other errors as well.
For instance a duplicated id yields 409 for which the current error is
very misleading.

In general the exception handling could use some refactoring. I don't really get why it's handling 400 special either. Some code comments would be useful here.