### PR TITLE
add support for app definitions with multiple apps in them

### DIFF
--- a/cli/tests/data/marathon/apps/zero_instance_sleep_v2_multiapp.json
+++ b/cli/tests/data/marathon/apps/zero_instance_sleep_v2_multiapp.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "zero-instance-app1",
+    "cmd": "sleep 2000",
+    "cpus": 0.1,
+    "mem": 16,
+    "instances": 0,
+    "labels": {
+      "PACKAGE_ID": "zero-instance-app",
+      "PACKAGE_VERSION": "1.2.3"
+    }
+  },
+  {
+    "id": "zero-instance-app2",
+    "cmd": "sleep 2000",
+    "cpus": 0.1,
+    "mem": 16,
+    "instances": 0,
+    "labels": {
+      "PACKAGE_ID": "zero-instance-app",
+      "PACKAGE_VERSION": "1.2.3"
+    }
+  }
+]

--- a/cli/tests/integrations/common.py
+++ b/cli/tests/integrations/common.py
@@ -245,6 +245,18 @@ def remove_app(app_id):
     assert_command(['dcos', 'marathon', 'app', 'remove', app_id])
 
 
+def remove_apps(app_ids):
+    """ Remove multiple apps
+
+    :param app_ids: list of ids of apps to remove
+    :type app_ids: list
+    :rtype: None
+    """
+
+    for app_id in app_ids:
+        remove_app(app_id)
+
+
 def package_install(package, deploy=False, args=[]):
     """ Calls `dcos package install`
 
@@ -467,7 +479,10 @@ def app(path, app_id, wait=True):
     try:
         yield
     finally:
-        remove_app(app_id)
+        if isinstance(app_id, list):
+            remove_apps(app_id)
+        else:
+            remove_app(app_id)
         watch_all_deployments()
 
 

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -290,7 +290,10 @@ class Client(object):
         else:
             app_json = app_resource
 
-        response = _http_req(http.post, url,
+        if not isinstance(app_json, list):
+            app_json = [app_json]
+
+        response = _http_req(http.put, url,
                              json=app_json,
                              timeout=self._timeout)
 


### PR DESCRIPTION
Marathon's /v2/apps API endpoint supports multiple apps. You can either PUT a single app `{}` or multiple apps `[{},{},{}]` in a single request. This PR adds support for the `dcos marathon` subcommand to handle multi app JSON files.