### PR TITLE
Add question about which missing library it is?

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Tox, our test runner, tests against both Python 2.7 and Python 3.4
 environments.
 
 If you're using OS X, be sure to use the officially distributed Python 3.4
-installer_ since the Homebrew version is missing a necessary library.
+installer_ since the Homebrew version is missing a necessary library *which library specifically and is this still a problem?*`.
 
 Running
 #######


### PR DESCRIPTION
There was no information about which library that is missing from the home-brew installation. Is this still a problem and if so could we add the details of which library is missing so that we can get home-brew updated eventually?