### PR TITLE
Revert "Enable shutdown test"

### DIFF
--- a/cli/tests/integrations/test_service.py
+++ b/cli/tests/integrations/test_service.py
@@ -5,6 +5,8 @@ import time
 import dcos.util as util
 from dcos.util import create_schema
 
+import pytest
+
 from ..fixtures.service import framework_fixture
 from .common import (assert_command, assert_lines, delete_zk_node,
                      delete_zk_nodes, exec_command, get_services,
@@ -197,6 +199,7 @@ def test_log_lines():
     assert_lines(['dcos', 'service', 'log', 'chronos', '--lines=4'], 4)
 
 
+@pytest.mark.skipif(True, reason='Broken Marathon but we need to release')
 def test_log_multiple_apps():
     package_install('marathon',
                     True,


### PR DESCRIPTION
Since it added 40min to the test run time.