### PR TITLE
Remove EXHIBITOR_URL environment variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,11 +123,6 @@ You can set :code:`DCOS_CONFIG` to a config file that points to a DCOS
 cluster you want to use for integration tests.  This defaults to
 :code:`~/.dcos/dcos.toml`
 
-If you are testing against the DCOS Image you can configure the URL to the
-Exhibitor::
-
-    export EXHIBITOR_URL=http://<hostname>:8181/
-
 There are two ways to run tests, you can either use the virtualenv created by
 :code:`make env` above::
 

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -9,7 +9,7 @@ deps =
   mock
   pytz
   -e..
-passenv = DCOS_* CI_FLAGS EXHIBITOR_URL VBOX_IP CLI_TEST_SSH_KEY_PATH CLI_TEST_MASTER_PROXY
+passenv = DCOS_* CI_FLAGS VBOX_IP CLI_TEST_SSH_KEY_PATH CLI_TEST_MASTER_PROXY
 
 [testenv:syntax]
 deps =

--- a/cli/tox.win.ini
+++ b/cli/tox.win.ini
@@ -4,7 +4,6 @@ envlist = py{27,34}-unit, py{27,34}-integration
 [testenv]
 setenv =
   DCOS_CONFIG = {env:DCOS_CONFIG}
-  EXHIBITOR_URL = {env:EXHIBITOR_URL}
 deps =
   teamcity-messages
   pytest

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
   teamcity-messages
   pytest
   pytest-cov
-passenv = DCOS_* CI_FLAGS EXHIBITOR_URL VBOX_IP CLI_TEST_SSH_KEY_PATH
+passenv = DCOS_* CI_FLAGS VBOX_IP CLI_TEST_SSH_KEY_PATH
 
 [testenv:syntax]
 deps =

--- a/tox.win.ini
+++ b/tox.win.ini
@@ -4,7 +4,6 @@ envlist = py{27,34}-unit
 [testenv]
 setenv =
   DCOS_CONFIG = {env:DCOS_CONFIG}
-  EXHIBITOR_URL = {env:EXHIBITOR_URL}
 deps =
   teamcity-messages
   pytest


### PR DESCRIPTION
We are not using the environment variable during the tests. Let's remove
all reference to it.