### PR TITLE
Make NamedTemporaryFile play nice on Windows

### DIFF
--- a/dcos/util.py
+++ b/dcos/util.py
@@ -50,6 +50,31 @@ def tempdir():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+@contextlib.contextmanager
+def temptext():
+    """A context manager for temporary files.
+
+    The lifetime of the returned temporary file corresponds to the
+    lexical scope of the returned file descriptor.
+
+    :return: reference to a temporary file
+    :rtype: (fd, str)
+    """
+
+    fd, path = tempfile.mkstemp()
+    try:
+        yield (fd, path)
+    finally:
+        # Close the file descriptor and ignore errors
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+        # delete the path
+        shutil.rmtree(path, ignore_errors=True)
+
+
 def sh_copy(src, dst):
     """Copy file src to the file or directory dst.
 


### PR DESCRIPTION
On Windows `NamedTemporaryFile` does not lend itself to be opened the second time when it is already open. Source : https://docs.python.org/2/library/tempfile.html

> 
Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows NT or later). 

Also closing the file would delete it by default. So to open the file second time on windows(and also not break on Unix like systems) the workaround is to set `delete=False` while creating the file, closing it after use and then manually deleting it after done.  

Without this fix you would see errors like : 
`
2016-02-09 16:09:02,290 c:\users\surdy\downloads\dcos\lib\site-package\dcos\subcommand.py:_execute_install:411 - Install script's stdout: b''
2016-02-09 16:09:02,290 c:\users\surdy\downloads\dcos\lib\site-packages\dcos\subcommand.py:_execute_install:412 - Install script's stderr: b"Could not open requirements file: [Errno 13] Permission denied: 'C:\\\\Users\\\\surdy\\\\AppData\\\\Local\\\\Temp\\\\tmpe9tm00ft'\r\nYou are using pip version 7.1.2, however version 8.0.2 is available.\r\nYou should consider upgrading via the 'python -m pip install --upgrade pip' command.\r\n
`