### PR TITLE
Don't use core as the user when an ssh config is provided

### DIFF
--- a/cli/dcoscli/service/main.py
+++ b/cli/dcoscli/service/main.py
@@ -271,9 +271,14 @@ def _log_marathon(follow, lines, ssh_config_file):
 
     leader_ip = marathon.create_client().get_leader().split(':')[0]
 
-    cmd = ("ssh {0}core@{1} " +
-           "journalctl {2}-u dcos-marathon").format(
+    user_string = 'core@'
+    if ssh_config_file:
+        user_string = ''
+
+    cmd = ("ssh {0}{1}{2} " +
+           "journalctl {3}-u dcos-marathon").format(
                ssh_options,
+               user_string,
                leader_ip,
                journalctl_args)
 


### PR DESCRIPTION
The ssh user for `dcos service` is hardcoded as `core` [here](https://github.com/mesosphere/dcos-cli/blob/5cf9ef0f1f14e63b5c6d0642ab380c7f8a08fc62/cli/dcoscli/service/main.py#L274). If you are a DCOS community edition user this works great. 

But if you are an Enterprise Edition customer you might not be on CoreOS. So you would want to use your own ssh_config for the hosts using `dcos service ----ssh-config-file`. Even if you have a `User` specified in the config file it won't be used since the hardcoded `core@` would take precedence over `User` in config file.  

There is no way to override,using a config, what's hardcoded the command line and I also understand to urge to keep  `core@` as default. So I have tweaked the code such that it does not use `core@` if you have a `--ssh-config-file` specified. 