### PR TITLE
fix username/password for capabilities endpoint

### DIFF
--- a/dcos/cosmospackage.py
+++ b/dcos/cosmospackage.py
@@ -1,4 +1,5 @@
 from dcos import emitting, http, util
+from dcos.errors import DCOSException, DCOSHTTPException
 
 from six.moves import urllib
 
@@ -18,12 +19,21 @@ class Cosmos:
 
         :rtype: bool
         """
+
         try:
             url = urllib.parse.urljoin(self.cosmos_url, 'capabilities')
             response = http.get(url,
                                 headers=_get_cosmos_header("capabilities"))
-        except Exception:
+        # return `Authentication failed` error messages, but all other errors
+        # are treated as endpoint not available
+        except DCOSHTTPException:
             return False
+        except DCOSException:
+            raise
+        except Exception as e:
+            logger.exception(e)
+            return False
+
         return response.status_code == 200
 
 

--- a/dcos/http.py
+++ b/dcos/http.py
@@ -120,7 +120,7 @@ def _request_with_auth(response,
 
     i = 0
     while i < 3 and response.status_code == 401:
-        parsed_url = urlparse(response.url)
+        parsed_url = urlparse(url)
         hostname = parsed_url.hostname
         auth_scheme, realm = get_auth_scheme(response)
         creds = (hostname, auth_scheme, realm)


### PR DESCRIPTION
/capabilites endpoint doesn't return url credentials in response, so use
request url. Also raise DCOSException, so we get `Authentication failed`
error message.