### PR TITLE
clean up `dcos package search --json` response

### DIFF
--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -478,7 +478,7 @@ def _search(json_, query):
     package_manager = _get_package_manager()
     results = package_manager.search_sources(query)
 
-    if any(result['packages'] for result in results) or json_:
+    if json_ or results['packages']:
         emitting.publish_table(emitter,
                                results,
                                tables.package_search_table,

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -305,10 +305,9 @@ def package_search_table(search_results):
     ])
 
     packages = []
-    for result in search_results:
-        for package in result['packages']:
-            package_ = copy.deepcopy(package)
-            packages.append(package_)
+    for package in search_results['packages']:
+        package_ = copy.deepcopy(package)
+        packages.append(package_)
 
     tb = table(fields, packages, sortby="NAME")
     tb.align['NAME'] = 'l'

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -746,10 +746,9 @@ def test_search():
         ['dcos', 'package', 'search', '--json'])
 
     registries = json.loads(stdout.decode('utf-8'))
-    for registry in registries:
-        # assert the number of packages is gte the number at the time
-        # this test was written
-        assert len(registry['packages']) >= 5
+    # assert the number of packages is gte the number at the time
+    # this test was written
+    assert len(registries['packages']) >= 5
 
     assert returncode == 0
     assert stderr == b''
@@ -775,10 +774,9 @@ def test_search_ends_with_wildcard():
     assert stderr == b''
 
     registries = json.loads(stdout.decode('utf-8'))
-    for registry in registries:
-        # cosmos matches wildcards in name/description/tags
-        # so will find more results (3 instead of 2)
-        assert len(registry['packages']) >= 2
+    # cosmos matches wildcards in name/description/tags
+    # so will find more results (3 instead of 2)
+    assert len(registries['packages']) >= 2
 
 
 def test_search_start_with_wildcard():
@@ -790,8 +788,7 @@ def test_search_start_with_wildcard():
     assert stderr == b''
 
     registries = json.loads(stdout.decode('utf-8'))
-    for registry in registries:
-        assert len(registry['packages']) == 1
+    assert len(registries['packages']) == 1
 
 
 def test_search_middle_with_wildcard():
@@ -803,8 +800,7 @@ def test_search_middle_with_wildcard():
     assert stderr == b''
 
     registries = json.loads(stdout.decode('utf-8'))
-    for registry in registries:
-        assert len(registry['packages']) == 1
+    assert len(registries['packages']) == 1
 
 
 def _get_app_labels(app_id):

--- a/cli/tests/unit/test_tables.py
+++ b/cli/tests/unit/test_tables.py
@@ -59,7 +59,7 @@ def test_package_table():
 
 def test_package_search_table():
     _test_table(tables.package_search_table,
-                [search_result_fixture()],
+                search_result_fixture(),
                 'tests/unit/data/package_search.txt')
 
 

--- a/dcos/cosmospackage.py
+++ b/dcos/cosmospackage.py
@@ -107,7 +107,7 @@ class Cosmos():
         :rtype: [packages]
         """
         response = self.cosmos_post("search", {"query": query})
-        return [response.json()]
+        return response.json()
 
     def get_package_version(self, package_name, package_version):
         """Returns PackageVersion of specified package


### PR DESCRIPTION
removed superfluous outer list of packages 
```json
{
  "packages": [
    {
      "currentVersion": "0.2.0-1",
      "description": "Apache Cassandra running on Apache Mesos",
      "framework": true,
      "name": "cassandra",
      "tags": [
        "data",
        "database",
        "nosql"
      ],
      "versions": {
        "0.2.0-1": "0"
      }
    }
  ]
}
```