### PR TITLE
Replaced broken link to the rest API in the --help results for dcos cli

### DIFF
--- a/cli/dcoscli/data/help/marathon.txt
+++ b/cli/dcoscli/data/help/marathon.txt
@@ -95,7 +95,7 @@ Positional Arguments:
                                 the definition is read from stdin. For a
                                 detailed description see
                                 (https://mesosphere.github.io/
-                                marathon/docs/rest-api.html#post-/v2/groups).
+                                marathon/docs/rest-api.html#post-v2-groups).
 
     <instances>                 The number of instances to start
 

--- a/cli/dcoscli/data/help/marathon.txt
+++ b/cli/dcoscli/data/help/marathon.txt
@@ -84,7 +84,7 @@ Positional Arguments:
                                 the definition is read from stdin. For a
                                 detailed description see
                                 (https://mesosphere.github.io/
-                                marathon/docs/rest-api.html#post-/v2/apps).
+                                marathon/docs/rest-api.html#post-v2-apps).
 
     <deployment-id>             The deployment id
 

--- a/cli/tests/data/help/marathon.txt
+++ b/cli/tests/data/help/marathon.txt
@@ -84,7 +84,7 @@ Positional Arguments:
                                 the definition is read from stdin. For a
                                 detailed description see
                                 (https://mesosphere.github.io/
-                                marathon/docs/rest-api.html#post-/v2/apps).
+                                marathon/docs/rest-api.html#post-v2-apps).
 
     <deployment-id>             The deployment id
 
@@ -95,7 +95,7 @@ Positional Arguments:
                                 the definition is read from stdin. For a
                                 detailed description see
                                 (https://mesosphere.github.io/
-                                marathon/docs/rest-api.html#post-/v2/groups).
+                                marathon/docs/rest-api.html#post-v2-groups).
 
     <instances>                 The number of instances to start
 


### PR DESCRIPTION
this 404's https://mesosphere.github.io/marathon/docs/rest-api.html#post-/v2/apps

