### PR TITLE
clean up toml test files

### DIFF
--- a/ccm/tests_ccm_cluster.sh
+++ b/ccm/tests_ccm_cluster.sh
@@ -7,4 +7,5 @@ set -x
 # run tests
 CLI_TEST_MASTER_PROXY=true \
 CLI_TEST_SSH_KEY_PATH=/dcos-cli/mesosphere-aws.key \
+echo "dcos_acs_token = \"$DCOS_ACS_TOKEN\"" >> /dcos-cli/cli/tests/data/dcos.toml && \
 ./bin/start_tests.sh

--- a/cli/tests/data/analytics/dcos_no_reporting.toml
+++ b/cli/tests/data/analytics/dcos_no_reporting.toml
@@ -1,3 +1,0 @@
-[core]
-reporting = false
-dcos_url = "http://dcos.snakeoil.mesosphere.com"

--- a/cli/tests/data/analytics/dcos_reporting.toml
+++ b/cli/tests/data/analytics/dcos_reporting.toml
@@ -1,4 +1,0 @@
-[core]
-dcos_acs_token = "foobar"
-dcos_url = "https://dcos.snakeoil.mesosphere.com"
-reporting = true

--- a/cli/tests/data/analytics/dcos_reporting_with_url.toml
+++ b/cli/tests/data/analytics/dcos_reporting_with_url.toml
@@ -1,3 +1,0 @@
-[core]
-reporting = true
-dcos_url = "http://dcos.snakeoil.mesosphere.com"

--- a/cli/tests/data/auth/dcos_with_credentials.toml
+++ b/cli/tests/data/auth/dcos_with_credentials.toml
@@ -1,2 +1,0 @@
-[core]
-reporting = false

--- a/cli/tests/data/auth/dcos_without_credentials.toml
+++ b/cli/tests/data/auth/dcos_without_credentials.toml
@@ -1,2 +1,0 @@
-[core]
-reporting = false

--- a/cli/tests/data/config/missing_params_dcos.toml
+++ b/cli/tests/data/config/missing_params_dcos.toml
@@ -1,4 +1,0 @@
-[core]
-reporting = false
-[package]
-cosmos_url = "http://localhost:7070"

--- a/cli/tests/data/marathon/missing_marathon_params.toml
+++ b/cli/tests/data/marathon/missing_marathon_params.toml
@@ -1,5 +1,0 @@
-[core]
-reporting = false
-[marathon]
-[package]
-cosmos_url = "http://localhost:7070"

--- a/cli/tests/data/ssl/ssl.toml
+++ b/cli/tests/data/ssl/ssl.toml
@@ -1,6 +1,0 @@
-[package]
-cosmos_url = "http://localhost:7070"
-[core]
-timeout = 5
-dcos_url = "https://dcos.snakeoil.mesosphere.com"
-reporting = false

--- a/cli/tests/integrations/test_auth.py
+++ b/cli/tests/integrations/test_auth.py
@@ -4,7 +4,7 @@ from dcos import constants
 
 import pytest
 
-from .common import assert_command, config_set, exec_command
+from .common import assert_command, exec_command, update_config
 
 
 @pytest.fixture
@@ -31,23 +31,22 @@ def test_version():
 
 
 def test_logout_no_token(env):
-    exec_command(['dcos', 'config', 'unset', 'core.dcos_acs_token'], env=env)
-
-    returncode, _, stderr = exec_command(
-        ['dcos', 'config', 'show', 'core.dcos_acs_token'], env=env)
-    assert returncode == 1
-    assert stderr == b"Property 'core.dcos_acs_token' doesn't exist\n"
+    with update_config("core.dcos_acs_token", None, env):
+        returncode, _, stderr = exec_command(
+            ['dcos', 'config', 'show', 'core.dcos_acs_token'], env=env)
+        assert returncode == 1
+        assert stderr == b"Property 'core.dcos_acs_token' doesn't exist\n"
 
 
 def test_logout_with_token(env):
-    config_set('core.dcos_acs_token', "foobar", env=env)
-    stderr = b"[core.dcos_acs_token]: changed\n"
-    assert_command(
-        ['dcos', 'config', 'set', 'core.dcos_acs_token', 'faketoken'],
-        stderr=stderr,
-        env=env)
+    with update_config("core.dcos_acs_token", "foobar", env):
+        stderr = b"[core.dcos_acs_token]: changed\n"
+        assert_command(
+            ['dcos', 'config', 'set', 'core.dcos_acs_token', 'faketoken'],
+            stderr=stderr,
+            env=env)
 
-    stderr = b'Removed [core.dcos_acs_token]\n'
-    assert_command(['dcos', 'auth', 'logout'],
-                   stderr=stderr,
-                   env=env)
+        stderr = b'Removed [core.dcos_acs_token]\n'
+        assert_command(['dcos', 'auth', 'logout'],
+                       stderr=stderr,
+                       env=env)

--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -6,7 +6,8 @@ from dcos import constants
 
 import pytest
 
-from .common import assert_command, config_set, config_unset, exec_command
+from .common import (assert_command, config_set, config_unset,
+                     exec_command, update_config)
 
 
 @pytest.fixture
@@ -17,17 +18,6 @@ def env():
         constants.DCOS_CONFIG_ENV: os.path.join("tests", "data", "dcos.toml"),
     })
 
-    return r
-
-
-@pytest.fixture
-def missing_env():
-    r = os.environ.copy()
-    r.update({
-        constants.PATH_ENV: os.environ[constants.PATH_ENV],
-        constants.DCOS_CONFIG_ENV:
-            os.path.join("tests", "data", "config", "missing_params_dcos.toml")
-    })
     return r
 
 
@@ -80,13 +70,15 @@ def test_invalid_dcos_url(env):
     stderr = b'Please check url \'abc.com\'. Missing http(s)://\n'
     assert_command(['dcos', 'config', 'set', 'core.dcos_url', 'abc.com'],
                    stderr=stderr,
-                   returncode=1)
+                   returncode=1,
+                   env=env)
 
 
 def test_get_top_property(env):
     stderr = (
         b"Property 'core' doesn't fully specify a value - "
         b"possible properties are:\n"
+        b"core.dcos_acs_token\n"
         b"core.dcos_url\n"
         b"core.reporting\n"
         b"core.ssl_verify\n"
@@ -95,10 +87,11 @@ def test_get_top_property(env):
 
     assert_command(['dcos', 'config', 'show', 'core'],
                    stderr=stderr,
-                   returncode=1)
+                   returncode=1,
+                   env=env)
 
 
-def test_set_package_sources_property(env):
+def test_set_package_sources_property():
     notice = (b"This config property has been deprecated. "
               b"Please add your repositories with `dcos package repo add`\n")
     assert_command(['dcos', 'config', 'set', 'package.sources', '[\"foo\"]'],
@@ -106,7 +99,7 @@ def test_set_package_sources_property(env):
                    returncode=1)
 
 
-def test_set_core_email_property(env):
+def test_set_core_email_property():
     notice = (b"This config property has been deprecated.\n")
     assert_command(['dcos', 'config', 'set', 'core.email', 'foo@bar.com'],
                    stderr=notice,
@@ -189,6 +182,7 @@ def test_unset_top_property(env):
     stderr = (
         b"Property 'core' doesn't fully specify a value - "
         b"possible properties are:\n"
+        b"core.dcos_acs_token\n"
         b"core.dcos_url\n"
         b"core.reporting\n"
         b"core.ssl_verify\n"
@@ -216,10 +210,10 @@ def test_set_property_key(env):
         env=env)
 
 
-def test_set_missing_property(missing_env):
-    config_set('core.dcos_url', 'http://localhost:8080', missing_env)
-    _get_value('core.dcos_url', 'http://localhost:8080', missing_env)
-    config_unset('core.dcos_url', missing_env)
+def test_set_missing_property(env):
+    with update_config("core.dcos_url", None, env=env):
+        config_set('core.dcos_url', 'http://localhost:8080', env)
+        _get_value('core.dcos_url', 'http://localhost:8080', env)
 
 
 def test_set_core_property(env):
@@ -272,19 +266,15 @@ def test_bad_port_fail_url_validation(env):
                          'http://localhost:bad_port/', env)
 
 
-def test_timeout(missing_env):
-    config_set('marathon.url', 'http://1.2.3.4', missing_env)
-    config_set('core.timeout', '1', missing_env)
+def test_timeout(env):
+    with update_config('marathon.url', 'http://1.2.3.4', env):
+        with update_config('core.timeout', '1', env):
+            returncode, stdout, stderr = exec_command(
+                ['dcos', 'marathon', 'app', 'list'], env=env)
 
-    returncode, stdout, stderr = exec_command(
-        ['dcos', 'marathon', 'app', 'list'], env=missing_env)
-
-    assert returncode == 1
-    assert stdout == b''
-    assert "(connect timeout=1)".encode('utf-8') in stderr
-
-    config_unset('core.timeout', missing_env)
-    config_unset('marathon.url', missing_env)
+            assert returncode == 1
+            assert stdout == b''
+            assert "(connect timeout=1)".encode('utf-8') in stderr
 
 
 def test_parse_error():

--- a/cli/tests/unit/test_http_auth.py
+++ b/cli/tests/unit/test_http_auth.py
@@ -121,7 +121,8 @@ def test_request_with_bad_auth_acl(mock, req_mock, auth_mock):
 
     with pytest.raises(DCOSException) as e:
         http._request_with_auth(mock, "method", mock.url)
-    assert e.exconly().split(':')[1].strip() == "Authentication failed"
+    msg = "Your core.dcos_acs_token is invalid. Please run: `dcos auth login`"
+    assert e.exconly().split(':', 1)[1].strip() == msg
 
 
 @patch('requests.Response')
@@ -138,7 +139,8 @@ def test_request_with_bad_oauth(mock, req_mock, auth_mock):
 
     with pytest.raises(DCOSException) as e:
         http._request_with_auth(mock, "method", mock.url)
-    assert e.exconly().split(':')[1].strip() == "Authentication failed"
+    msg = "Your core.dcos_acs_token is invalid. Please run: `dcos auth login`"
+    assert e.exconly().split(':', 1)[1].strip() == msg
 
 
 @patch('requests.Response')


### PR DESCRIPTION
Instead of using different toml files in tests, just alter the config value for that test. This makes the tests more manageable especially since we now need to add auth credentials in the toml file. 