### PR TITLE
Added functionality to 'dcos marathon task stop <task_id> --wipe' in …

### DIFF
--- a/cli/dcoscli/data/help/marathon.txt
+++ b/cli/dcoscli/data/help/marathon.txt
@@ -27,6 +27,7 @@ Usage:
     dcos marathon group remove [--force] <group-id>
     dcos marathon group update [--force] <group-id> [<properties>...]
     dcos marathon task list [--json <app-id>]
+    dcos marathon task stop [--wipe] <task-id>
     dcos marathon task show <task-id>
 
 Commands:
@@ -74,6 +75,8 @@ Commands:
         Update a group.
     task list
         List all tasks.
+    task stop
+        Stop a task. Wipe persistent data if `--wipe` is set.
     task show
         List a specific task.
 

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -72,6 +72,11 @@ def _cmds():
             function=_task_list),
 
         cmds.Command(
+            hierarchy=['marathon', 'task', 'stop'],
+            arg_keys=['<task-id>', '--wipe'],
+            function=_task_stop),
+
+        cmds.Command(
             hierarchy=['marathon', 'task', 'show'],
             arg_keys=['<task-id>'],
             function=_task_show),
@@ -778,6 +783,27 @@ def _task_list(app_id, json_):
     tasks = client.get_tasks(app_id)
 
     emitting.publish_table(emitter, tasks, tables.app_task_table, json_)
+    return 0
+
+
+def _task_stop(task_id, wipe):
+    """Stop a Marathon task
+
+    :param task_id: the id of the task
+    :type task_id: str
+    :param wipe: whether to wipe persistent data and unreserve resources
+    :type wipe: bool
+    :returns: process return code
+    :rtype: int
+    """
+
+    client = marathon.create_client()
+    task = client.stop_task(task_id, wipe)
+
+    if task is None:
+        raise DCOSException("Task '{}' does not exist".format(task_id))
+
+    emitter.publish(task)
     return 0
 
 

--- a/cli/tests/data/dcos.toml
+++ b/cli/tests/data/dcos.toml
@@ -1,5 +1,5 @@
 [core]
-reporting = false
-timeout = 5
 dcos_url = "http://dcos.snakeoil.mesosphere.com"
+timeout = 5
+reporting = false
 ssl_verify = "false"

--- a/cli/tests/data/help/marathon.txt
+++ b/cli/tests/data/help/marathon.txt
@@ -27,6 +27,7 @@ Usage:
     dcos marathon group remove [--force] <group-id>
     dcos marathon group update [--force] <group-id> [<properties>...]
     dcos marathon task list [--json <app-id>]
+    dcos marathon task stop [--wipe] <task-id>
     dcos marathon task show <task-id>
 
 Commands:
@@ -74,6 +75,8 @@ Commands:
         Update a group.
     task list
         List all tasks.
+    task stop
+        Stop a task. Wipe persistent data if `--wipe` is set.
     task show
         List a specific task.
 

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -669,6 +669,37 @@ class Client(object):
 
         return task
 
+    def stop_task(self, task_id, wipe=None):
+        """Stops a task.
+
+        :param task_id: the ID of the task
+        :type task_id: str
+        :param wipe: whether remove reservations and persistent volumes.
+        :type wipe: bool
+        :returns: a tasks
+        :rtype: dict
+        """
+
+        if not wipe:
+            params = None
+        else:
+            params = {'wipe': 'true'}
+
+        url = self._create_url('v2/tasks/delete')
+
+        response = _http_req(http.post,
+                             url,
+                             params=params,
+                             json={'ids': [task_id]},
+                             timeout=self._timeout)
+
+        task = next(
+            (task for task in response.json()['tasks']
+             if task_id == task['id']),
+            None)
+
+        return task
+
     def get_app_schema(self):
         """Returns app json schema
 


### PR DESCRIPTION
…order to wipe stateful services

Background:
I’ve started writing a deep dive on setting up [stateful services in marathon](https://github.com/dcos/dcos-docs/pull/66). One thing is wiping a task from state including reservations and persistent volumes. That’s possible in marathon via a POST to `/v2/tasks/delete` (yes, POST to /delete, don’t ask) as described here https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-tasks-delete – for the sake of having the deep dive tutorial merely on dcos cli without any direct marathon api interaction, I’ve added the tasks delete command. It doesn’t cover all possibilities of the marathon api, but it would be good to be able to wipe tasks via the cli, I guess.